### PR TITLE
Create Minimal Firmware On ESPHome Addon Import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
         file: # TODO: Rename
           - Integrations/ESPHome/H-1.yaml
           - Integrations/ESPHome/H-1D.yaml
+          - Integrations/ESPHome/H-1_Minimal.yaml
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4.1.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        file: # TODO: Rename
+        file:
           - Integrations/ESPHome/H-1.yaml
           - Integrations/ESPHome/H-1D.yaml
           - Integrations/ESPHome/H-1_Minimal.yaml
+        esphome-version:
+          - stable
+          - beta
+          - dev
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4.1.7

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -309,7 +309,7 @@ light:
           lambda: |-
             for (int i = 0; i < it.size(); i++) {
               // Generate a random brightness factor between 50% and 100%
-              float brightness_factor = 0.5 + (esp_random() % 30) / 75.0;
+              float brightness_factor = 0.5 + (rand() % 30) / 75.0;
 
               // Apply brightness to white color (255, 255, 255) for a twinkle effect
               int white_r = 255 * brightness_factor;

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "24.11.25.1"
+  version: "24.12.19.1"
 
 esp32:
   board: esp32-c3-devkitm-1
@@ -72,6 +72,24 @@ button:
     name: "Factory Reset"
     entity_category: diagnostic
     internal: true
+  - platform: template
+    id: btn_play_song_1
+    name: "Play Song 1"
+    on_press:
+      then:
+        - script.execute: play_song_1
+  - platform: template
+    id: btn_play_song_2
+    name: "Play Song 2"
+    on_press:
+      then:
+        - script.execute: play_song_2
+  - platform: template
+    id: btn_play_song_3
+    name: "Play Song 3"
+    on_press:
+      then:
+        - script.execute: play_song_3
 
 number:
   - platform: template

--- a/Integrations/ESPHome/H-1_Minimal.yaml
+++ b/Integrations/ESPHome/H-1_Minimal.yaml
@@ -1,13 +1,13 @@
 esphome:
   name: "apollo-h-1"
-  friendly_name: Apollo H-1
-  comment: Apollo H-1
+  friendly_name: Apollo H-1 Minimal
+  comment: Apollo H-1 Minimal
   name_add_mac_suffix: true
   platformio_options:
     board_build.flash_mode: dio
 
   project:
-    name: "ApolloAutomation.H-1"
+    name: "ApolloAutomation.H-1_Minimal"
     version: "${version}"
 
   min_version: 2023.11.1
@@ -41,32 +41,11 @@ dashboard_import:
 
 improv_serial:
 
-esp32_improv:
-  authorizer: none
-
 ota:
   - platform: esphome
     id: ota_esphome
-  - platform: http_request
-    id: ota_managed
-
-http_request:
-  verify_ssl: true
-
-safe_mode:
-
-update:
-  - platform: http_request
-    id: firmware_update
-    name: Firmware Update
-    source: https://apolloautomation.github.io/H-1/artifact/manifest.json
 
 wifi:
-  on_connect:
-    - delay: 5s
-    - ble.disable:
-  on_disconnect:
-    - ble.enable:
   ap:
     ssid: "Apollo H1 Hotspot"
 


### PR DESCRIPTION
Version: 24.12.19.1

Adds:
- Buttons to control lights/songs

Fixes:
- ESPHome import being too large

Breaks:



Checks:
- [ ] Documentation Updated
- [ ] Build Number Incremented In Core.yaml
