### PR TITLE
Remove RMT channel due to update failures

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -249,7 +249,6 @@ light:
     id: rgb_light
     name: "RGB Light"
     pin: GPIO3
-    rmt_channel: 0
     default_transition_length: 0s
     chipset: WS2812
     num_leds: 22

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "24.12.19.1"
+  version: "25.2.19.1"
 
 esp32:
   board: esp32-c3-devkitm-1


### PR DESCRIPTION
https://github.com/esphome/issues/issues/6771#issuecomment-2668798671

Fixes: 2025.2 Updates

Breaks: Older versions?


Checks:
- [x] Documentation Updated
- [x] Build Number Incremented In Core.yaml
