### PR TITLE
Fix firmware update system (404 manifest URL, stale first check)

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,6 +2,7 @@ name-template: 'Release v$NEXT_PATCH_VERSION'
 tag-template: "$RESOLVED_VERSION"
 change-template: "- #$NUMBER $TITLE @$AUTHOR"
 sort-direction: ascending
+category-template: '**$TITLE**'
 
 categories:
   - title: "🚨 Breaking changes"
@@ -41,11 +42,9 @@ include-labels:
 
 no-changes-template: '- No changes'
 
+# The shared build workflow appends a Full Changelog compare link to the
+# release body (release-drafter cannot render 4-part version tags).
 template: |
-  ## What's Changed
+  **What's Changed**
 
   $CHANGES
-
-  **Full Changelog**: https://github.com/ApolloAutomation/H-1/compare/$PREVIOUS_TAG...$RESOLVED_VERSION.1
-
-   Be sure to 🌟 this repository for updates!

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       yaml-files: |
         Integrations/ESPHome/H-1.yaml
         Integrations/ESPHome/H-1D.yaml
-      firmware-names: "1:firmware,1D:firmare-d"
+      firmware-names: "1:firmware,1D:firmware-d"
       core-yaml-path: Integrations/ESPHome/Core.yaml
       esphome-version: stable
       # Bypass check if manually triggered with bypass option

--- a/Integrations/ESPHome/H-1.yaml
+++ b/Integrations/ESPHome/H-1.yaml
@@ -59,12 +59,13 @@ update:
   - platform: http_request
     id: firmware_update
     name: Firmware Update
-    source: https://apolloautomation.github.io/H-1/artifact/manifest.json
+    source: https://apolloautomation.github.io/H-1/firmware/manifest.json
 
 wifi:
   on_connect:
     - delay: 5s
     - ble.disable:
+    - component.update: firmware_update
   on_disconnect:
     - ble.enable:
   ap:


### PR DESCRIPTION
While rolling the R_PRO-1 managed update system out to other devices we audited every repo's manifest URLs, and H-1's is broken in production:

## Fixes

- **The Firmware Update entity has never worked**: it points at `https://apolloautomation.github.io/H-1/artifact/manifest.json`, which is a 404 — CI publishes to `/H-1/firmware/manifest.json` (200). Devices fail every check with `ESP_ERR_HTTP_CONNECT`-style errors and show "up to date" forever.
- **Manifest check on WiFi connect**: the update component's first 6-hour poll fires before the network is up and skips silently, so even with the URL fixed the entity would be stale for ~6h after every boot. Added `component.update: firmware_update` to the existing `wifi.on_connect` automation.
- **`firmare-d` → `firmware-d` typo** in the H-1D publish directory name. Nothing references the misspelled path today (H-1D has no update entity), so the rename is safe.

## Not included

H-1D has no update entity at all. It's a deep-sleep battery device (prevent-sleep defaults off), so giving it the update system means deciding the wake/check policy — left for a separate discussion. Once added it should point at the (now correctly spelled) `firmware-d` manifest.

H-1.yaml compile-verified on ESPHome 2026.1.3.