### PR TITLE
Auto-assign on fork PRs via pull_request_target

### DIFF
--- a/.github/workflows/autoassign.yml
+++ b/.github/workflows/autoassign.yml
@@ -1,9 +1,12 @@
 name: Auto Assign
 
+# pull_request_target (not pull_request) so auto-assign works on
+# fork-submitted PRs; fork pull_request runs only get a read-only token.
+# Safe because this workflow never checks out or executes PR code.
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 permissions:
@@ -12,8 +15,6 @@ permissions:
 
 jobs:
   auto-assign:
-    # Skip auto-assign for pull requests from forks due to GITHUB_TOKEN permission restrictions
-    if: github.event_name == 'issues' || github.event.pull_request.head.repo.full_name == github.repository
     uses: ApolloAutomation/Workflows/.github/workflows/autoassign.yml@main
     with:
       assignees: bharvey88


### PR DESCRIPTION
Standardize auto-assign so it runs on PRs opened from forks.

The auto-assign workflow triggers on `pull_request` (or skips forks via an `if:` guard), so fork-submitted PRs never get auto-assigned — fork `pull_request` runs only receive a read-only `GITHUB_TOKEN`. This switches to `pull_request_target`, drops the fork-skip guard, and pins the assignee to bharvey88.

`pull_request_target` runs in the base-repo context with a write token. Safe here because the workflow never checks out or executes PR code — it only assigns.

Targeting the default branch (`main`) because GitHub runs the auto-assign workflow from the default branch for `issues` / `pull_request_target` events; a fix only on `beta` would stay inert. Matches ApolloAutomation/MSR-2#84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
