### PR TITLE
Pin shared reusable workflows to a commit SHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build-and-publish:
-    uses: ApolloAutomation/Workflows/.github/workflows/build.yml@main
+    uses: ApolloAutomation/Workflows/.github/workflows/build.yml@430d90dc695c6f7d1075c4e4a0df4b13a6496252 # main 2026-07-23
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -17,4 +17,4 @@ permissions:
 jobs:
   label-check:
     name: Label Check
-    uses: ApolloAutomation/Workflows/.github/workflows/label-check.yml@main
+    uses: ApolloAutomation/Workflows/.github/workflows/label-check.yml@430d90dc695c6f7d1075c4e4a0df4b13a6496252 # main 2026-07-23


### PR DESCRIPTION
<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: 25.12.4.1 (unchanged, workflow only)

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?

Pins the two `ApolloAutomation/Workflows` reusable workflow references (build, label-check) from the mutable `@main` ref to the current reviewed commit SHA, matching how the repo already pins third-party actions. This keeps a change to the Workflows repo from silently altering what runs here.

Trade-off: future Workflows updates need a pin bump in this repo.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [x] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
